### PR TITLE
Add PlaylistPro to Spotify Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@
 
 - [SpotTransfer](https://github.com/Pushan2005/SpotTransfer) - Spotify to YT-Music Migration Tool.
 
+- [PlaylistPro](https://playlistpro.pro) - Organize your liked songs or any playlist: split into multiple playlists, sort by BPM, key and audio features, remove duplicates, bulk-move tracks, and view listening insights.
+
 ### ➤ Spotify Themes
 
 - 🌟 [Spotify Customizer](https://github.com/Darkempire78/Spotify-Customizer) / [Spicetify Bloom](https://github.com/nimsandu/spicetify-bloom) / [Spicetify Fluent](https://github.com/williamckha/spicetify-fluent) / [Colorify](https://colorify.live/) / [Nord-Spotify](https://github.com/Tetrax-10/Nord-Spotify)


### PR DESCRIPTION
Adding PlaylistPro (https://playlistpro.pro) to the Spotify Tools section.

Disclosure: I built it. It works on your liked songs or any playlist, and can split them into multiple playlists automatically (by genre, BPM range, key, decade and more), sort by BPM, musical/Camelot key, energy and other audio features, remove duplicates, and bulk-move tracks to several playlists at once. It also has top tracks, top artists and recently played pages.

Runs entirely in the browser, free, no account beyond your Spotify login. Happy to shorten the description or move it if another section fits better.